### PR TITLE
Finishes work on data set construction

### DIFF
--- a/data/recomp.py
+++ b/data/recomp.py
@@ -46,12 +46,40 @@ def loadUsers(users, files):
       })
 
 def convertToTagRatings(movies, tags, users):
+  for user in users:
+    totals = {}
+    for movieIdx, rating in user['ratings']:
+      for idx in movies[movieIdx]['tags']:
+        if idx in totals:
+          total, count = totals[idx]
+          totals[idx] = (total + rating, count + 1)
+        else:
+          totals[idx] = (rating, 1)
+    user['ratings'] = [(idx, totals[idx][0] / totals[idx][1]) for idx in totals.keys()]
+    print(user['id'])
+
+def filterTagsByCount(movies, tags, users, minHits):
+  oldTagCount = len(tags)
+  tags[:] = [tag for tag in tags if tag['count'] > minHits]
+
+  tagMap = {}
+  reIndex(tags, tagMap)
+
+  removedTagInstances = 0
+  for movie in movies:
+    oldMovieTags = len(movie['tags'])
+    movie['tags'] = [tagMap[idx] for idx in movie['tags'] if idx in tagMap]
+    removedTagInstances += oldMovieTags - len(movie['tags'])
+
+  return {
+    'removedTags': oldTagCount - len(tags),
+    'removedTagInstances': removedTagInstances
+  }
+
+def filterTagsByRatings(movies, tags, users):
   1
 
-def filterTagsByRatings(tags, users):
-  1
-
-def filterMoviesByTags(movies, tags, minMovies):
+def filterTaglessMovies(movies, tags, users):
   1
 
 def filterMoviesByRatings(movies, users):
@@ -94,7 +122,7 @@ if __name__ == '__main__':
   subparsers = parser.add_subparsers(dest = 'output')
   subparsers.required = True
   parserTags = subparsers.add_parser('tags')
-  parserTags.add_argument('-t', '--tagcount', default = 2000, type = int)
+  parserTags.add_argument('-c', '--count', default = 1400, type = int)
   parserMovies = subparsers.add_parser('movies')
   args = parser.parse_args()
 
@@ -105,10 +133,21 @@ if __name__ == '__main__':
     loadMovies(movies, inMovies)
     loadTags(tags, inTags)
     loadUsers(users, inUsers)
+    print(filterTagsByCount(movies, tags, users, args.count))
     convertToTagRatings(movies, tags, users)
-    filterTagsByCount(movies, tags, users, args.tagcount)
-    fitlerTagsByRatings(movies, tags, users)
-    filterTaglessMovies(movies, tags, users)
+
+    f = open('dump.csv', 'w')
+    print('Minimum,Maximum,Average', file = f)
+    for user in users:
+      r = list(zip(*user['ratings']))[1]
+      mn = min(r)
+      mx = max(r)
+      av = sum(r) / len(r)
+      print('{},{},{}'.format(mn, mx, av), file = f)
+      print('{}, {}, {}'.format(mn, mx, av))
+
+    #fitlerTagsByRatings(movies, tags, users)
+    #filterTaglessMovies(movies, tags, users)
   elif args.output == 'movies':
     loadMovies(movies, inMovies)
     loadUsers(users, inUsers)


### PR DESCRIPTION
Interesting plot of movie ratings vs. averaged ratings for tags:
http://isenseproject.org/projects/1000/data_sets/8570

Finishes recomp.py.  Running with "tags" as the data set construction option works as well.  It requires about 5 GB of memory to run.

Running with "movies" generates two files:
recommend.mat - matrix with users as rows and their ratings of movies as the columns
movies.lookup - text file where a movie's line number is equal to the column number in recommend.mat

Running with "tags" generates three files:
recommend.mat - matrix with users as rows and their averaged ratings of movies by tags as the columns.
movietags.mat - matrix with movies as rows, and their tags as columns, values are either 0 (movie does not have tag) or 1 (movie has tag)
movies.lookup - text file where a movie's line number is equal to the row number in movietags.mat

Run with "tags" to generate the data set that incorporates tags, run with "movies" to generate the data set that doesn't incorporate tags.  Don't run both or the one that you run second will overwrite the first's data.
